### PR TITLE
Update bot.py

### DIFF
--- a/Discord_Bot_Cosmos_Proposals/bot.py
+++ b/Discord_Bot_Cosmos_Proposals/bot.py
@@ -6,7 +6,7 @@ import pytz
 from requests import get
 
 
-client = discord.Client()
+client = discord.Client(intents=discord.Intents.default())
 
 
 def app(update, context):


### PR DESCRIPTION
Current bot.py yields `TypeError: Client.__init__() missing 1 required keyword-only argument: 'intents'`, PR specifies default.

[API Reference](https://discordpy.readthedocs.io/en/latest/api.html?highlight=client#intents)
[Migrating to discord.py v2.0](https://discordpy.readthedocs.io/en/latest/migrating.html#intents-are-now-required)